### PR TITLE
Activate ELMO functionality in Box Model

### DIFF
--- a/CCTM/src/box_io/m3utilio.f
+++ b/CCTM/src/box_io/m3utilio.f
@@ -438,7 +438,7 @@ C   begin body of function  DT2STR
         DATBUF = ''
         DATBUF = MMDDYY( J )
         
-        DT2STR = TRIM( TIMBUF ) // TRIM( DATBUF )
+        DT2STR = TIMBUF // DATBUF
 
         RETURN
 
@@ -1333,12 +1333,14 @@ C   begin body of function  TRIMLEN
 
             ! check to make sure no blank string is passed & call c function
             ! mio_setenvvarc
+            print *,'Setting ENVVAR ',trim(env_name),' to ',trim(env_value) 
+
             if ( ( env_name_len .eq. 0 ) .or. (env_value_len .eq. 0 ) ) then
               setenvvar = .false.
               return
             else
               setenvvar = 
-     &        ( setenvvarc ( env_name, env_name_len,env_value, env_value_len ) .gt. 0 )
+     &        ( setenvvarc ( env_name, env_name_len,env_value,env_value_len ) .eq. 0 )
             endif
             if( setenvvar )then
               call nameval(env_name,test_value)

--- a/CCTM/src/box_io/mio_setenvvarc.c
+++ b/CCTM/src/box_io/mio_setenvvarc.c
@@ -46,7 +46,7 @@
 #define SETENVVARC  setenvvarc_
 #endif
 
-#elif 
+#else 
 
 #ifndef SETENVVARC 
 #define SETENVVARC  setenvvarc
@@ -72,7 +72,7 @@ int SETENVVARC( const char * ename,  int *strlen1,
         memcpy(putstr+*strlen1+1, evalue, *strlen2);  
         putstr[*strlen1+*strlen2+1] = '\0';
         ierr = putenv(putstr);
-        printf("setenvvarc result: '%s'\n",getenv(ename));
+        /** printf("setenvvarc result: '%s'\n",getenv(ename)); **/
       }
       else { /** malloc error **/ 
         ierr = -1; 

--- a/CCTM/src/box_io/xtract_metgeodata.f
+++ b/CCTM/src/box_io/xtract_metgeodata.f
@@ -1,6 +1,7 @@
         LOGICAL FUNCTION XTRACT_METGEODATA( VNAME,VNAME_VALUE )
 
            USE SCENE_DATA
+           USE RUNTIME_VARS, ONLY : LOGDEV, OUTDEV
 
            IMPLICIT NONE
 
@@ -168,14 +169,14 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
    
             IF (  VNAME .EQ. 'ZH'  ) THEN
                   VNAME_VALUE  = BXM_ZH
-                  print*,'XTRACT_METGEODATA: BXM_ZH,ZH = ',BXM_ZH,VNAME_VALUE
+                  WRITE( LOGDEV, '(A,F,2X,F)'),'XTRACT_METGEODATA: BXM_ZH,ZH = ',BXM_ZH,VNAME_VALUE
                   XTRACT_METGEODATA = .TRUE.
                   RETURN
             ENDIF
 
             IF (  VNAME .EQ. 'ZF'  ) THEN
                   VNAME_VALUE  = BXM_ZF
-                  print*,'XTRACT_METGEODATA: BXM_ZF,ZF = ',BXM_ZF,VNAME_VALUE
+                  WRITE( LOGDEV, '(A,F,2X,F)'),'XTRACT_METGEODATA: BXM_ZF,ZF = ',BXM_ZF,VNAME_VALUE
                   XTRACT_METGEODATA = .TRUE.
                   RETURN
             ENDIF
@@ -254,7 +255,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
             IF ( VNAME(1:7) .EQ. 'LUFRAC_' ) THEN
               IF ( TRIM(VNAME) .EQ. TRIM(BXM_LU) ) THEN
                  VNAME_VALUE = 1.0
-                 print*,'XTRACT_METGEODATA: ',TRIM(VNAME),' = ', VNAME_VALUE
+                 WRITE( LOGDEV, '(A,A,A3,F)'),'XTRACT_METGEODATA: ',TRIM(VNAME),' = ', VNAME_VALUE
               ELSE
                  VNAME_VALUE = 0.0
               END IF

--- a/CCTM/src/box_io/xtract_metgeodata.f
+++ b/CCTM/src/box_io/xtract_metgeodata.f
@@ -169,14 +169,12 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
    
             IF (  VNAME .EQ. 'ZH'  ) THEN
                   VNAME_VALUE  = BXM_ZH
-                  WRITE( LOGDEV, '(A,F,2X,F)'),'XTRACT_METGEODATA: BXM_ZH,ZH = ',BXM_ZH,VNAME_VALUE
                   XTRACT_METGEODATA = .TRUE.
                   RETURN
             ENDIF
 
             IF (  VNAME .EQ. 'ZF'  ) THEN
                   VNAME_VALUE  = BXM_ZF
-                  WRITE( LOGDEV, '(A,F,2X,F)'),'XTRACT_METGEODATA: BXM_ZF,ZF = ',BXM_ZF,VNAME_VALUE
                   XTRACT_METGEODATA = .TRUE.
                   RETURN
             ENDIF
@@ -251,16 +249,17 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
                RETURN
             ENDIF
 
-! Assuming NLCD40 is set LANDUSE scheme in centralized_io_module   
-            IF ( VNAME(1:7) .EQ. 'LUFRAC_' ) THEN
-              IF ( TRIM(VNAME) .EQ. TRIM(BXM_LU) ) THEN
-                 VNAME_VALUE = 1.0
-                 WRITE( LOGDEV, '(A,A,A3,F)'),'XTRACT_METGEODATA: ',TRIM(VNAME),' = ', VNAME_VALUE
-              ELSE
-                 VNAME_VALUE = 0.0
+! Assuming NLCD40 is set LANDUSE scheme in centralized_io_module 
+            IF ( LEN( VNAME ) .GE. 7 ) THEN
+              IF ( VNAME(1:7) .EQ. 'LUFRAC_' ) THEN
+                IF ( TRIM(VNAME) .EQ. TRIM(BXM_LU) ) THEN
+                   VNAME_VALUE = 1.0
+                ELSE
+                   VNAME_VALUE = 0.0
+                END IF
+                XTRACT_METGEODATA = .TRUE.
+                RETURN
               END IF
-              XTRACT_METGEODATA = .TRUE.
-              RETURN
             END IF
 
             RETURN

--- a/CCTM/src/cio/centralized_io_module.F
+++ b/CCTM/src/cio/centralized_io_module.F
@@ -7587,11 +7587,11 @@ c search box initial conditions
       
             BUFFER = 1.0E-30
             IF( PRESENT( FNAME ) )THEN
-              PRINT*,"Interpolate_Var_3DGRID: Unknown file and Variable, ",TRIM(FNAME)," and ",TRIM(VNAME)
+              WRITE( LOGDEV, '(4A)'),"Interpolate_Var_3DGRID: Unknown file and Variable, ",TRIM(FNAME)," and ",TRIM(VNAME)
             ELSE
-              PRINT*,"Interpolate_Var_3DGRID: Variable, ",TRIM(VNAME)
+              WRITE( LOGDEV, '(2A)'),"Interpolate_Var_3DGRID: Variable, ",TRIM(VNAME)
             END IF
-            PRINT*,"Setting ", TRIM(VNAME),' to 1.0E-30'
+            WRITE( LOGDEV, '(3A)'),"Setting ", TRIM(VNAME),' to 1.0E-30'
             RETURN
 
         END SUBROUTINE R_INTERPOLATE_VAR_3DGRID
@@ -7640,11 +7640,11 @@ c search box initial conditions
 
         BUFFER = 1.0E-30
         IF( PRESENT( FNAME ) )THEN
-           PRINT*,"Interpolate_Var_2DGRID: Unknown file and Variable, ",TRIM(FNAME)," and ",TRIM(VNAME)
+           WRITE( LOGDEV, '(4A)'),"Interpolate_Var_2DGRID: Unknown file and Variable, ",TRIM(FNAME)," and ",TRIM(VNAME)
         ELSE
-           PRINT*,"Interpolate_Var_2DGRID: Unknown Variable, ",TRIM(VNAME)
+           WRITE( LOGDEV, '(2A)'),"Interpolate_Var_2DGRID: Unknown Variable, ",TRIM(VNAME)
         END IF
-        PRINT*,"Setting ", TRIM(VNAME),' to 1.0E-30'
+        WRITE( LOGDEV, '(3A)'),"Setting ", TRIM(VNAME),' to 1.0E-30'
             
         RETURN
 

--- a/CCTM/src/driver/ELMO_INIT_DEFN.F
+++ b/CCTM/src/driver/ELMO_INIT_DEFN.F
@@ -19,7 +19,7 @@
       MODULE ELMO_INIT_DEFN
 
       USE ELMO_DATA
-      USE RUNTIME_VARS, ONLY : LOGDEV,LOG_MESSAGE,LOG_HEADING,LOG_SUBHEADING
+      USE RUNTIME_VARS, ONLY : LOGDEV,LOG_MESSAGE,LOG_HEADING,LOG_SUBHEADING, OUTDEV
       
       CONTAINS
 !-------------------------------------------------------------------------
@@ -228,8 +228,12 @@
       CHARACTER(32), ALLOCATABLE :: FILE_VARS(:,:)
       CHARACTER(32), ALLOCATABLE :: KEYWD_NAME( : )
       CHARACTER(32), ALLOCATABLE :: KEYWD(:,:)
-                       
+
+#ifdef m3box
+      CHARACTER( 200 ) :: SUFFIX = '.csv'
+#else
       CHARACTER( 200 ) :: SUFFIX = '.nc'
+#endif
       CHARACTER( 16 ), SAVE :: PNAME = 'READ_ELMO_NML'
       CHARACTER( 200 )   :: XMSG
       CHARACTER( 200 )   :: TMPLINE
@@ -377,19 +381,11 @@
             ELMO_FILE( IFL )%FILENAME = TRIM( OUTDIR ) // '/' // 
      &                                  TRIM( ELMO_FILE( IFL )%FILENAME )
         END IF
-#ifdef m3box
-!shut off ELMO for boxmodel untit version of IOAPI setenvvar is developed
-      N_ELMO_FILES = 0
-!close m3box
-#endif
 #ifndef mpas
-#ifndef m3box
         IF ( .NOT. SETENVVAR( ELMO_FILE( IFL )%FLOGICAL, ELMO_FILE( IFL )%FILENAME ) ) THEN
             WRITE( XMSG, '(A,I3)' ) 'ERROR: Could not set environment variable for ELMO file # ', IFL
             CALL M3EXIT( PNAME, 0, 0, XMSG, 1 )
         END IF
-!close m3box
-#endif
 #endif
 
         ! Output Time Step
@@ -1396,13 +1392,13 @@
      &                        TRIM( AEROSPC(IAER)%NAME(IM) )
                         ELSE IF ( ORG_OP .EQ. OT_OC .OR. ORG_OP .EQ. OT_DD_OC .OR. 
      &                            ORG_OP .EQ. OT_WD_OC ) THEN
-                           WRITE( FORMULA, '(A,A,A1,ES8.2)' ) TRIM(FORMULA),
+                           WRITE( FORMULA, '(A,A,A1,ES9.2)' ) TRIM(FORMULA),
      &                        TRIM( AEROSPC(IAER)%NAME(IM) ),'/',OASPC(IOA)%OMtoOC
                         ELSE IF ( ORG_OP .EQ. OT_OMOC ) THEN
-                           WRITE( FORMULA, '(A,ES8.2,A1,A)' ) TRIM(FORMULA),
+                           WRITE( FORMULA, '(A,ES9.2,A1,A)' ) TRIM(FORMULA),
      &                        OASPC(IOA)%OMtoOC,'*',TRIM(AEROSPC(IAER)%NAME(IM) )
                         ELSE IF ( ORG_OP .EQ. OT_OTOC ) THEN
-                           WRITE( FORMULA, '(A,ES8.2,A1,A)' ) TRIM(FORMULA),
+                           WRITE( FORMULA, '(A,ES9.2,A1,A)' ) TRIM(FORMULA),
      &                        OASPC(IOA)%OtoC,'*',TRIM( AEROSPC(IAER)%NAME(IM) )
                         END IF
 

--- a/CCTM/src/vdiff/acm2/ASX_DATA_MOD.F
+++ b/CCTM/src/vdiff/acm2/ASX_DATA_MOD.F
@@ -934,7 +934,6 @@ C-------------------------------- MET_CRO_3D --------------------------------
 
 C-------------------------------- MET_CRO_2D --------------------------------
 C Vegetation and surface vars
-#ifndef m3box
          call interpolate_var ('LAI', jdate, jtime, Met_Data%LAI)
 
          call interpolate_var ('VEG', jdate, jtime, Met_Data%VEG)
@@ -958,16 +957,13 @@ C Soil vars
          If ( BIOGEMIS_BEIS ) Then
             call interpolate_var ('SOIT2', jdate, jtime, Met_Data%SOIT2)
          End If
-#endif
          
          call interpolate_var ('SEAICE', jdate, jtime, Met_Data%SEAICE)
 
 C met vars
 
          call interpolate_var ('PRSFC', jdate, jtime, Met_Data%PRSFC)
-#ifndef m3box
          call interpolate_var ('RGRND', jdate, jtime, Met_Data%RGRND)
-#endif
          call interpolate_var ('SNOCOV', jdate, jtime, Met_Data%SNOCOV)
 
          Where( Met_Data%SNOCOV .Lt. 0.0 )
@@ -978,7 +974,6 @@ C met vars
 
          call interpolate_var ('TEMPG', jdate, jtime, Met_Data%TEMPG)
 
-#ifndef m3box
          call interpolate_var ('USTAR', jdate, jtime, Met_Data%USTAR)
 
          call interpolate_var ('WSPD10', jdate, jtime, Met_Data%WSPD10)
@@ -992,7 +987,6 @@ C met vars
          End If
 
          call interpolate_var ('PBL', jdate, jtime, Met_Data%PBL)
-#endif
 
         ! Update for WRFV4.1+ PX LSM runs that have soil texture in output for
         !  CMAQ dust scheme. These are initialized to 0 if not present in MCIP.
@@ -1025,7 +1019,6 @@ C Met_cro_2D variables that have recently changed due to MCIP or WRF/CMAQ
             Met_Data%TSEASFC = Met_Data%TEMPG
          End If
 
-#ifndef m3box
          If ( .not. RA_RS_AVAIL ) Then
             call interpolate_var ('RADYNI', jdate, jtime, Met_Data%RA)
 
@@ -1050,7 +1043,6 @@ C Met_cro_2D variables that have recently changed due to MCIP or WRF/CMAQ
             call interpolate_var ('RS', jdate, jtime, Met_Data%RS)
 
          End If
-#endif
 
          If ( Q2_AVAIL ) Then  ! Q2 in METCRO2D
             call interpolate_var ('Q2', jdate, jtime, Met_Data%Q2)
@@ -1086,7 +1078,6 @@ C Met_cro_2D variables that have recently changed due to MCIP or WRF/CMAQ
          MET_DATA%RH = MIN( 0.9999, MAX( 0.001, MET_DATA%RH ) )
  
 
-#ifndef m3box
 #ifndef mpas
 C-------------------------------- MET_DOT_3D --------------------------------
          call interpolate_var (vname_uc, jdate, jtime, Met_Data%UWIND)
@@ -1096,7 +1087,6 @@ C-------------------------------- MET_DOT_3D --------------------------------
 C get ghost values for wind fields in case of free trop.
          CALL SUBST_COMM ( Met_Data%UWIND, DSPL_N0_E1_S0_W0, DRCN_E )
          CALL SUBST_COMM ( Met_Data%VWIND, DSPL_N1_E0_S0_W0, DRCN_N )
-#endif
 #endif
 
 C-------------------------------- Calculated Variables --------------------------------

--- a/CCTM/src/vdiff/acm2/ASX_DATA_MOD.F
+++ b/CCTM/src/vdiff/acm2/ASX_DATA_MOD.F
@@ -934,6 +934,7 @@ C-------------------------------- MET_CRO_3D --------------------------------
 
 C-------------------------------- MET_CRO_2D --------------------------------
 C Vegetation and surface vars
+#ifndef m3box
          call interpolate_var ('LAI', jdate, jtime, Met_Data%LAI)
 
          call interpolate_var ('VEG', jdate, jtime, Met_Data%VEG)
@@ -957,15 +958,16 @@ C Soil vars
          If ( BIOGEMIS_BEIS ) Then
             call interpolate_var ('SOIT2', jdate, jtime, Met_Data%SOIT2)
          End If
-
+#endif
+         
          call interpolate_var ('SEAICE', jdate, jtime, Met_Data%SEAICE)
 
 C met vars
 
          call interpolate_var ('PRSFC', jdate, jtime, Met_Data%PRSFC)
-
+#ifndef m3box
          call interpolate_var ('RGRND', jdate, jtime, Met_Data%RGRND)
-
+#endif
          call interpolate_var ('SNOCOV', jdate, jtime, Met_Data%SNOCOV)
 
          Where( Met_Data%SNOCOV .Lt. 0.0 )
@@ -976,6 +978,7 @@ C met vars
 
          call interpolate_var ('TEMPG', jdate, jtime, Met_Data%TEMPG)
 
+#ifndef m3box
          call interpolate_var ('USTAR', jdate, jtime, Met_Data%USTAR)
 
          call interpolate_var ('WSPD10', jdate, jtime, Met_Data%WSPD10)
@@ -989,6 +992,7 @@ C met vars
          End If
 
          call interpolate_var ('PBL', jdate, jtime, Met_Data%PBL)
+#endif
 
         ! Update for WRFV4.1+ PX LSM runs that have soil texture in output for
         !  CMAQ dust scheme. These are initialized to 0 if not present in MCIP.
@@ -1021,6 +1025,7 @@ C Met_cro_2D variables that have recently changed due to MCIP or WRF/CMAQ
             Met_Data%TSEASFC = Met_Data%TEMPG
          End If
 
+#ifndef m3box
          If ( .not. RA_RS_AVAIL ) Then
             call interpolate_var ('RADYNI', jdate, jtime, Met_Data%RA)
 
@@ -1045,6 +1050,7 @@ C Met_cro_2D variables that have recently changed due to MCIP or WRF/CMAQ
             call interpolate_var ('RS', jdate, jtime, Met_Data%RS)
 
          End If
+#endif
 
          If ( Q2_AVAIL ) Then  ! Q2 in METCRO2D
             call interpolate_var ('Q2', jdate, jtime, Met_Data%Q2)
@@ -1080,6 +1086,7 @@ C Met_cro_2D variables that have recently changed due to MCIP or WRF/CMAQ
          MET_DATA%RH = MIN( 0.9999, MAX( 0.001, MET_DATA%RH ) )
  
 
+#ifndef m3box
 #ifndef mpas
 C-------------------------------- MET_DOT_3D --------------------------------
          call interpolate_var (vname_uc, jdate, jtime, Met_Data%UWIND)
@@ -1089,6 +1096,7 @@ C-------------------------------- MET_DOT_3D --------------------------------
 C get ghost values for wind fields in case of free trop.
          CALL SUBST_COMM ( Met_Data%UWIND, DSPL_N0_E1_S0_W0, DRCN_E )
          CALL SUBST_COMM ( Met_Data%VWIND, DSPL_N1_E0_S0_W0, DRCN_N )
+#endif
 #endif
 
 C-------------------------------- Calculated Variables --------------------------------


### PR DESCRIPTION
Setenvvar and setenvvarc are updated to successfully set environment variables. ELMO can now create output file names and proceed with output. These data are written to CSV files which upon first inspection, look correctly articulated.

Minor changes were also made to the destination of some warnings -- from the screen to the log file.

Minor changes were made to number formats in ELMO to reduce compiler warning messages.

Compile directives were added so that data extraction calls from ASX_DATA_MOD are skipped for variables that are not present or expected (e.g. WSPD10).